### PR TITLE
chore: bump model to gpt-4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/alkshmir/go-openai-discord
 
-go 1.22
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	github.com/bwmarrin/discordgo v0.28.1

--- a/openai_chatbot.go
+++ b/openai_chatbot.go
@@ -91,7 +91,7 @@ func (bot *OpenAIChatBot) FakeReply(prompt string) (string, error) {
 
 func (bot *OpenAIChatBot) newContext() openai.ChatCompletionRequest {
 	return openai.ChatCompletionRequest{
-		Model: openai.GPT4o,
+		Model: "gpt-4.1",
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role:    openai.ChatMessageRoleSystem,


### PR DESCRIPTION
since go-openai does not yet support gpt-4.1, `Model` is coded as string.
Once upstream go-openai is updated, I'll use predefined symbols for model identifier.